### PR TITLE
Change Google Fonts URLs from insecure URLs to secure https URLs

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -11,7 +11,7 @@
   used under CC BY http://creativecommons.org/licenses/by/4.0/
   Modified icons to fit ionicon’s grid from original.
 */
-@import url("http://fonts.googleapis.com/css?family=Roboto:900,700,100,300,400|Source+Code+Pro:400,600");
+@import url("https://fonts.googleapis.com/css?family=Roboto:900,700,100,300,400|Source+Code+Pro:400,600");
 @font-face {
   font-family: "Ionicons";
   src: url("../fonts/ionicons.eot?v=2.0.0");

--- a/public/scss/helpers/fonts.scss
+++ b/public/scss/helpers/fonts.scss
@@ -1,1 +1,1 @@
-@import url('http://fonts.googleapis.com/css?family=Roboto:900,700,100,300,400|Source+Code+Pro:400,600');
+@import url('https://fonts.googleapis.com/css?family=Roboto:900,700,100,300,400|Source+Code+Pro:400,600');

--- a/src/views/errors/404.blade.php
+++ b/src/views/errors/404.blade.php
@@ -1,6 +1,6 @@
 <html>
 	<head>
-		<link href='http://fonts.googleapis.com/css?family=Lato:100' rel='stylesheet' type='text/css'>
+		<link href='https://fonts.googleapis.com/css?family=Lato:100' rel='stylesheet' type='text/css'>
 
 		<style>
 			body {

--- a/src/views/installer/assets.blade.php
+++ b/src/views/installer/assets.blade.php
@@ -6,7 +6,7 @@
     <title>Welcome To Devise | Installing Assets</title>
 
 	<style>
-	@import url("http://fonts.googleapis.com/css?family=Roboto:100");
+	@import url("https://fonts.googleapis.com/css?family=Roboto:100");
 
 	body {
 		background-color:#2D3039;


### PR DESCRIPTION
Various CSS-related URLs pointing at http://fonts.googleapis.com... cause a mixed content warning when Devise is run on an https site.

For a long time, the advice was to use protocol-less URLs, e.g.:

//fonts.googleapis.com/css?family=...

Current advise is to use https wherever possible.

FYI I think there are other http links lurking away. I can try to hunt them down when less tired at the end of the day :-)